### PR TITLE
Correct port in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the README file for directions. You'll need Python 2.7 installed too.
    cd appengine-endpoints-helloendpoints-python
    dev_appserver.py .
    ```
-1. Test your Endpoints by visiting the Google APIs Explorer (by default [http://localhost:8000/_ah/api/explorer](http://localhost:8000/_ah/api/explorer))
+1. Test your Endpoints by visiting the Google APIs Explorer (by default [http://localhost:8080/_ah/api/explorer](http://localhost:8080/_ah/api/explorer))
 
 ## Deploy
 To deploy the application:


### PR DESCRIPTION
GAE SDK runs on 8000. Instance itself runs on 8080. http://localhost:8000/_ah/api/explorer gives 404 http://localhost:8080/_ah/api/explorer sends you to the apis explorer.
